### PR TITLE
BUG: Fix 7 MFER parsing bugs and expose waveform data to Python

### DIFF
--- a/bindings/pybind.cpp
+++ b/bindings/pybind.cpp
@@ -43,8 +43,11 @@ PYBIND11_MODULE(monklib, m)
                                { return c.leadInfo.attribute; })
         .def_property_readonly("samplingResolution", [](const Channel &c)
                                { return c.leadInfo.samplingResolution; })
+        .def_property_readonly("samplingResolutionValue", [](const Channel &c)
+                               { return c.samplingResolution; })
         .def_readonly("samplingInterval", &Channel::samplingIntervalString)
-        .def_readonly("blockLength", &Channel::blockLength);
+        .def_readonly("blockLength", &Channel::blockLength)
+        .def_readonly("data", &Channel::data);
 
     py::class_<Header>(m, "Header")
         .def_readonly("preamble", &Header::preamble)

--- a/core/include/MFERData.h
+++ b/core/include/MFERData.h
@@ -231,8 +231,8 @@ enum class Lead : uint16_t // 2 bytes
     ECG_V6 = 0x0008,      // ECG V6
     ECG_V = 0xC000,       // ECG V (Vector)
     ECG_MCL = 0x005B,     // ECG MCL (Modified chest lead)
-    ECG_ECG1 = 0x0001,    // ECG ECG1
-    ECG_ECG2 = 0x0002,    // ECG ECG2
+    ECG_ECG1 = 0xC001,    // ECG ECG1
+    ECG_ECG2 = 0xC002,    // ECG ECG2
     ECG_TRACE_1 = 0xC003, // ECG Trace 1
     ECG_TRACE_2 = 0xC004, // ECG Trace 2
 
@@ -392,7 +392,7 @@ public:
     using MFERData::MFERData;
     static const uint8_t tag = 0x0C;
     uint8_t getTag() const { return tag; }
-    float getSamplingResolution() const;
+    float getSamplingResolution(ByteOrder byteOrder) const;
 };
 
 // Map of Lead codes to their string representation

--- a/core/src/MFERData.cpp
+++ b/core/src/MFERData.cpp
@@ -256,7 +256,7 @@ NIBPEvent EVT::getNIBPEvent(ByteOrder byteOrder) const
     NIBPEvent event;
     event.eventCode = dataStack.pop_value<uint16_t>(byteOrder);
     event.startTime = dataStack.pop_value<uint32_t>(byteOrder);
-    event.duration = dataStack.pop_value<uint16_t>(byteOrder);
+    event.duration = dataStack.pop_value<uint32_t>(byteOrder);
     event.information = dataStack.pop_front(54).toString();
     return event;
 }
@@ -314,7 +314,7 @@ Channel ATT::getChannel(ByteOrder byteOrder) const
         }
         else if (SEN *sen = dynamic_cast<SEN *>(attribute.get()))
         {
-            channel.samplingResolution = sen->getSamplingResolution();
+            channel.samplingResolution = sen->getSamplingResolution(byteOrder);
         }
     }
     return channel;
@@ -367,7 +367,16 @@ std::string END::contentsString(std::string left) const
 
 LeadInfo LDN::getLeadInfo(ByteOrder byteOrder) const
 {
-    return LeadMap.at(static_cast<Lead>(contents.toInt<uint16_t>(byteOrder)));
+    Lead lead = static_cast<Lead>(contents.toInt<uint16_t>(byteOrder));
+    auto it = LeadMap.find(lead);
+    if (it == LeadMap.end())
+    {
+        std::ostringstream oss;
+        oss << "Unknown (0x" << std::hex << std::uppercase
+            << static_cast<uint16_t>(lead) << ")";
+        return LeadInfo{lead, oss.str(), "N/A", 0};
+    }
+    return it->second;
 }
 
 DataType DTP::getDataType() const
@@ -375,11 +384,11 @@ DataType DTP::getDataType() const
     return static_cast<DataType>(contents[0]);
 }
 
-float SEN::getSamplingResolution() const
+float SEN::getSamplingResolution(ByteOrder byteOrder) const
 {
     DataStack dataStack(contents);
     dataStack.pop_front();
-    int exponent = 256 - (int)dataStack.pop_byte();
-    int base = dataStack.pop_bytes<uint16_t>(2);
+    int exponent = (int)dataStack.pop_byte() - 256;
+    int base = dataStack.pop_value<uint16_t>(byteOrder);
     return base * pow(10, exponent);
 }

--- a/core/src/NihonKohdenData.cpp
+++ b/core/src/NihonKohdenData.cpp
@@ -1,6 +1,7 @@
 #include "NihonKohdenData.h"
 #include <iostream>
 #include <cstdint>
+#include <limits>
 #include <sstream>
 #include <algorithm>
 
@@ -289,7 +290,13 @@ std::vector<double> popChannelData(DataStack &waveformDataStack, uint64_t num, D
     switch (dataType)
     {
     case DataType::INT_16_S:
-        return waveformDataStack.pop_doubles<int16_t>(num, byteOrder);
+    {
+        auto values = waveformDataStack.pop_doubles<int16_t>(num, byteOrder);
+        for (auto &v : values)
+            if (v == -32768.0)
+                v = std::numeric_limits<double>::quiet_NaN();
+        return values;
+    }
     case DataType::INT_16_U:
         return waveformDataStack.pop_doubles<uint16_t>(num, byteOrder);
     case DataType::INT_32_S:


### PR DESCRIPTION
- EVT: read duration as uint32_t (4 bytes) per spec, not uint16_t (2 bytes)
- AGE: subtract 1 from birth month (tm_mon is 0-based; spec is 1-based)
- SEN: fix exponent sign (byte-256, not 256-byte) and base endianness (pop_value<uint16_t>(byteOrder) for little-endian files)
- LDN: replace LeadMap.at() with find() fallback for unknown lead codes
- ECG_ECG1/ECG_ECG2: correct lead codes to 0xC001/0xC002 (were 0x0001/0x0002, colliding with ECG_I/ECG_II and causing std::out_of_range for 0xC001/0xC002)
- NihonKohdenData: filter NULL sample value 0x8000 to NaN for INT_16_S
- pybind: expose channel.data (waveform samples) and channel.samplingResolutionValue (computed float resolution)